### PR TITLE
[Feat] 디자인 피드백 업데이트

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,8 @@
         "jwt-decode": "^4.0.0",
         "lodash": "^4.17.21",
         "react": "^18.2.0",
+        "react-dnd": "^16.0.1",
+        "react-dnd-html5-backend": "^16.0.1",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.48.1",
         "react-router-dom": "^6.17.0",
@@ -3310,6 +3312,21 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@react-dnd/asap": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@react-dnd/asap/-/asap-5.0.2.tgz",
+      "integrity": "sha512-WLyfoHvxhs0V9U+GTsGilGgf2QsPl6ZZ44fnv0/b8T3nQyvzxidxsg/ZltbWssbsRDlYW8UKSQMTGotuTotZ6A=="
+    },
+    "node_modules/@react-dnd/invariant": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@react-dnd/invariant/-/invariant-4.0.2.tgz",
+      "integrity": "sha512-xKCTqAK/FFauOM9Ta2pswIyT3D8AQlfrYdOi/toTPEhqCuAs1v5tcJ3Y08Izh1cJ5Jchwy9SeAXmMg6zrKs2iw=="
+    },
+    "node_modules/@react-dnd/shallowequal": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@react-dnd/shallowequal/-/shallowequal-4.0.2.tgz",
+      "integrity": "sha512-/RVXdLvJxLg4QKvMoM5WlwNR9ViO9z8B/qPcc+C0Sa/teJY7QG7kJ441DwzOjMYEY7GmU4dj5EcGHIkKZiQZCA=="
     },
     "node_modules/@remix-run/router": {
       "version": "1.10.0",
@@ -6888,6 +6905,16 @@
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="
     },
+    "node_modules/dnd-core": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-16.0.1.tgz",
+      "integrity": "sha512-HK294sl7tbw6F6IeuK16YSBUoorvHpY8RHO+9yFfaJyCDVb6n7PRcezrOEOa2SBCqiYpemh5Jx20ZcjKdFAVng==",
+      "dependencies": {
+        "@react-dnd/asap": "^5.0.1",
+        "@react-dnd/invariant": "^4.0.1",
+        "redux": "^4.2.0"
+      }
+    },
     "node_modules/dns-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
@@ -8991,6 +9018,19 @@
       "bin": {
         "he": "bin/he"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/hoopy": {
       "version": "0.1.4",
@@ -14795,6 +14835,43 @@
         "node": ">=8"
       }
     },
+    "node_modules/react-dnd": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-16.0.1.tgz",
+      "integrity": "sha512-QeoM/i73HHu2XF9aKksIUuamHPDvRglEwdHL4jsp784BgUuWcg6mzfxT0QDdQz8Wj0qyRKx2eMg8iZtWvU4E2Q==",
+      "dependencies": {
+        "@react-dnd/invariant": "^4.0.1",
+        "@react-dnd/shallowequal": "^4.0.1",
+        "dnd-core": "^16.0.1",
+        "fast-deep-equal": "^3.1.3",
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "peerDependencies": {
+        "@types/hoist-non-react-statics": ">= 3.3.1",
+        "@types/node": ">= 12",
+        "@types/react": ">= 16",
+        "react": ">= 16.14"
+      },
+      "peerDependenciesMeta": {
+        "@types/hoist-non-react-statics": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-dnd-html5-backend": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/react-dnd-html5-backend/-/react-dnd-html5-backend-16.0.1.tgz",
+      "integrity": "sha512-Wu3dw5aDJmOGw8WjH1I1/yTH+vlXEL4vmjk5p+MHxP8HuHJS1lAGeIdG/hze1AvNeXWo/JgULV87LyQOr+r5jw==",
+      "dependencies": {
+        "dnd-core": "^16.0.1"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
@@ -15022,6 +15099,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
       }
     },
     "node_modules/reflect.getprototypeof": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "jwt-decode": "^4.0.0",
     "lodash": "^4.17.21",
     "react": "^18.2.0",
+    "react-dnd": "^16.0.1",
+    "react-dnd-html5-backend": "^16.0.1",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.48.1",
     "react-router-dom": "^6.17.0",

--- a/src/App.css
+++ b/src/App.css
@@ -1064,11 +1064,15 @@ li.page-btn button {
   justify-content: center;
   align-items: center;
   width: 50px;
+  height: 100%;
+  font-size: 25px;
+  font-weight: 600;
   text-align: center;
   opacity: 0.6;
+  cursor: pointer;
 }
 .scoring li:hover,
-.scoring li:focus-within {
+.scoring li.active {
   opacity: 1;
 }
 .scoring li.check-correct {
@@ -1081,11 +1085,9 @@ li.page-btn button {
   border-top-right-radius: 15px;
   border-bottom-right-radius: 15px;
 }
-.scoring li button {
-  width: 100%;
-  font-size: 25px;
-  font-weight: 600;
+.scoring li label {
   cursor: pointer;
+  padding: 8px 15px;
 }
 
 /* TestScreen.tsx */
@@ -1124,6 +1126,7 @@ input[type="radio"]:checked + .custom-button {
   font-family: "Noto Sans KR", sans-serif;
   font-weight: 700;
   font-size: 35px;
+  word-break: keep-all;
 }
 .test-contents.test-contents__width-full {
   width: 100%;
@@ -1283,9 +1286,6 @@ input[type="radio"]:checked + .custom-button {
 }
 .test-contents__answer-wrapper .scoring {
   width: inherit;
-}
-.test-contents__answer-wrapper .scoring button {
-  height: 100%;
 }
 
 .config-figure {

--- a/src/App.css
+++ b/src/App.css
@@ -486,6 +486,15 @@
   height: 50px;
   border-radius: 50px;
 }
+.close-button {
+  position: absolute;
+  top: 5px;
+  right: 20px;
+  border-radius: 5px;
+  padding: 10px 15px;
+  font-size: 20px;
+  font-weight: 800;
+}
 
 /* Home.tsx */
 .contents-wrapper.main {

--- a/src/App.css
+++ b/src/App.css
@@ -930,17 +930,27 @@ li.page-btn button {
 .test-list-table th:last-child {
   width: 12%;
 }
-.progress {
-  width: 90%;
-  height: 20px;
+.stamp {
+  display: inline-block;
+  width: 25px;
+  height: 25px;
+  margin: 0 20px;
+  background-color: #fff;
+  border: 1px solid var(--black);
+  border-radius: 50%;
+  opacity: 0.3;
 }
-.progress-percent {
-  margin-left: 24px;
+.stamp.active {
+  background-color: #63a4db;
 }
 .test-start-btn {
   display: flex;
   justify-content: center;
   align-items: center;
+  width: 100%;
+  font-family: "SCoreDream";
+  font-weight: 500;
+  font-size: 16px;
 }
 .test-start-btn img {
   width: 100%;
@@ -1103,17 +1113,6 @@ input[type="checkbox"]:checked + .custom-button,
 input[type="radio"]:checked + .custom-button {
   opacity: 1;
 }
-/* .answer-buttons button {
-  opacity: 0.6;
-}
-.answer-buttons button:hover,
-.answer-buttons button:focus {
-  opacity: 1;
-}
-.answer-buttons .answer-buttons__opacity_1 {
-  opacity: 1;
-  padding: 0;
-} */
 
 .test-contents {
   position: relative;

--- a/src/App.css
+++ b/src/App.css
@@ -152,7 +152,7 @@
   height: 48px;
   width: 366px;
   font-weight: 500;
-  font-size: 1.2em;
+  font-size: 1.6em;
   line-height: 22px;
   outline: none;
   color: #ffffff;
@@ -416,9 +416,8 @@
   align-items: center;
   width: 1280px;
   height: 100%;
-  background: transparent
-    linear-gradient(270deg, #619fdf 0%, #74ccba 81%, #75ceb9 100%) 0% 0%
-    no-repeat padding-box;
+  background: transparent linear-gradient(270deg, #619fdf 0%, #74ccba 81%, #75ceb9 100%)
+    0% 0% no-repeat padding-box;
   margin: 0 auto;
   padding: 0 30px;
 }
@@ -1096,7 +1095,15 @@ li.page-btn button {
   top: -100px;
   width: 100%;
 }
-.answer-buttons button {
+input[type="checkbox"] + .custom-button,
+input[type="radio"] + .custom-button {
+  opacity: 0.6;
+}
+input[type="checkbox"]:checked + .custom-button,
+input[type="radio"]:checked + .custom-button {
+  opacity: 1;
+}
+/* .answer-buttons button {
   opacity: 0.6;
 }
 .answer-buttons button:hover,
@@ -1106,7 +1113,7 @@ li.page-btn button {
 .answer-buttons .answer-buttons__opacity_1 {
   opacity: 1;
   padding: 0;
-}
+} */
 
 .test-contents {
   position: relative;

--- a/src/App.css
+++ b/src/App.css
@@ -454,6 +454,8 @@
 /* UserModal */
 .modal-wrapper {
   position: fixed;
+  top: 0;
+  left: 0;
   width: 100%;
   height: 100%;
   background-color: rgba(0, 0, 0, 0.363);

--- a/src/App.css
+++ b/src/App.css
@@ -779,6 +779,9 @@
   font-weight: 800;
   font-size: 45px;
 }
+input[type="radio"] + .custom-button.answer-buttons__opacity_1 {
+  opacity: 1;
+}
 
 /* Test04Menu.tsx */
 .functions-wrapper.menus .card-wide {

--- a/src/App.css
+++ b/src/App.css
@@ -833,17 +833,6 @@ input[type="radio"] + .custom-button.answer-buttons__opacity_1 {
   width: 100%;
   max-width: 45px;
 }
-.test-screen__sequencing-input {
-  width: 50px;
-  height: 50px;
-  margin-right: 20px;
-  text-align: center;
-  background-color: #eef6f9;
-  border: 1px solid #81a8b7;
-  font-family: "Montserrat", sans-serif;
-  font-size: 20px;
-  font-weight: bold;
-}
 
 /* Test05Menu.tsx */
 .main-title.menu.no-margin-bottom {

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,37 +1,32 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
 import { useRecoilState } from "recoil";
-import {
-  myPageModalState,
-  globalConfigModalState,
-  gConfigState,
-} from "@states/index";
+import { modalState, globalConfigModalState, gConfigState } from "@states/index";
 
 export default function Header() {
-  const [myPageModal, setMyPageModal] = useRecoilState(myPageModalState);
-  const [globalConfigModal, setGlobalConfigModal] = useRecoilState(
-    globalConfigModalState
-  );
+  const [modal, setModal] = useRecoilState(modalState);
+  const [globalConfigModal, setGlobalConfigModal] =
+    useRecoilState(globalConfigModalState);
 
   return (
     <>
-      {myPageModal && <MyPageModal setMyPageModal={setMyPageModal} />}
+      {modal && <MyPageModal setModal={setModal} />}
       {globalConfigModal && (
-        <GlobalConfigModal setGlobalConfigModal={setGlobalConfigModal} />
+        <GlobalConfigModal
+          setGlobalConfigModal={setGlobalConfigModal}
+          setModal={setModal}
+        />
       )}
       <header className="header-wrapper">
         <div className="header">
           <div className="nav">
-            <h2 className="app-title">말귀연습</h2>
+            <h2 className="app-title">말귀</h2>
             <Link to="/home" className="link-home">
               HOME
             </Link>
           </div>
           <div className="nav">
-            <figure
-              className="config-figure"
-              onClick={() => setGlobalConfigModal(true)}
-            >
+            <figure className="config-figure" onClick={() => setGlobalConfigModal(true)}>
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 fill="none"
@@ -54,7 +49,7 @@ export default function Header() {
             <Link to="/" className="logout-btn">
               로그아웃
             </Link>
-            <figure onClick={() => setMyPageModal(true)}>
+            <figure onClick={() => setModal(true)}>
               <img
                 src={`${process.env.PUBLIC_URL}/images/home/user.png`}
                 alt="User Icon"
@@ -67,9 +62,9 @@ export default function Header() {
   );
 }
 
-function MyPageModal({ setMyPageModal }: any) {
+function MyPageModal({ setModal }: any) {
   return (
-    <div className="modal-wrapper" onClick={() => setMyPageModal(false)}>
+    <div className="modal-wrapper" onClick={() => setModal(false)}>
       <div className="modal">
         <img
           src={`${process.env.PUBLIC_URL}/images/home/user.png`}
@@ -117,7 +112,7 @@ function GlobalConfigModal({ setGlobalConfigModal }: any) {
   };
 
   return (
-    <div className="modal-wrapper">
+    <div className="modal-wrapper" onClick={() => setGlobalConfigModal(false)}>
       <div className="modal">
         <p className="modal-name">전역 설정</p>
         <ul>
@@ -154,10 +149,7 @@ function GlobalConfigModal({ setGlobalConfigModal }: any) {
           <li>
             <div>노이즈종류</div>
             <div>
-              <select
-                defaultValue={globalConfig.noise}
-                onChange={handleNoiseChange}
-              >
+              <select defaultValue={globalConfig.noise} onChange={handleNoiseChange}>
                 <option value="noise1">기본</option>
                 <option value="noise2">길거리</option>
                 <option value="noise3">식당</option>

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -1,0 +1,20 @@
+export default function Modal({ setModal, modalText }: any) {
+  const handleClose = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setModal(false);
+  };
+  const handleModalContentClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+  };
+
+  return (
+    <div className="modal-wrapper" onClick={handleClose} style={{ height: "110%" }}>
+      <div className="modal" onClick={handleModalContentClick}>
+        <p>{modalText}</p>
+        <button className="close-button" onClick={handleClose}>
+          X
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -8,7 +8,7 @@ export default function Modal({ setModal, modalText }: any) {
   };
 
   return (
-    <div className="modal-wrapper" onClick={handleClose} style={{ height: "110%" }}>
+    <div className="modal-wrapper" onClick={handleClose}>
       <div className="modal" onClick={handleModalContentClick}>
         <p>{modalText}</p>
         <button className="close-button" onClick={handleClose}>

--- a/src/components/tests/CustomInputButton.tsx
+++ b/src/components/tests/CustomInputButton.tsx
@@ -5,6 +5,8 @@ interface CustomInputButtonProps {
   id: string;
   imageName: string;
   name: string;
+  className: string;
+  onClick: () => void;
 }
 
 export default function CustomInputButton({
@@ -12,6 +14,8 @@ export default function CustomInputButton({
   id,
   imageName,
   name,
+  className,
+  onClick,
 }: CustomInputButtonProps) {
   const [checked, setChecked] = useState(false);
 
@@ -30,8 +34,9 @@ export default function CustomInputButton({
         hidden
       />
       <label
-        className="custom-button"
+        className={`custom-button ${className}`}
         htmlFor={id}
+        onClick={onClick}
         style={{
           display: "inline-block",
           width: "151px",

--- a/src/components/tests/CustomInputButton.tsx
+++ b/src/components/tests/CustomInputButton.tsx
@@ -1,0 +1,45 @@
+import { ChangeEvent, useState } from "react";
+
+interface CustomInputButtonProps {
+  type: string;
+  id: string;
+  imageName: string;
+  name: string;
+}
+
+export default function CustomInputButton({
+  type,
+  id,
+  imageName,
+  name,
+}: CustomInputButtonProps) {
+  const [checked, setChecked] = useState(false);
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setChecked(e.target.checked);
+  };
+
+  return (
+    <>
+      <input
+        type={type}
+        id={id}
+        name={name}
+        checked={checked}
+        onChange={handleChange}
+        hidden
+      />
+      <label
+        className="custom-button"
+        htmlFor={id}
+        style={{
+          display: "inline-block",
+          width: "151px",
+          height: "131px",
+          backgroundImage: `url(${process.env.PUBLIC_URL}/images/test/${imageName}.png)`,
+          cursor: "pointer",
+        }}
+      ></label>
+    </>
+  );
+}

--- a/src/components/tests/TestList.tsx
+++ b/src/components/tests/TestList.tsx
@@ -46,9 +46,7 @@ function TestList({ partNum, data, _to }: TestListProps) {
                   key={page}
                   className={`page-btn ${page === currentPage ? "active" : ""}`}
                 >
-                  <button onClick={() => _handlePageNumber(page)}>
-                    {page}
-                  </button>
+                  <button onClick={() => _handlePageNumber(page)}>{page}</button>
                 </li>
               );
             })}
@@ -68,8 +66,9 @@ function TestList({ partNum, data, _to }: TestListProps) {
                 <tr key={k}>
                   <td>{k}</td>
                   <td>
-                    <progress className="progress" value={0} max={100} />
-                    <span className="progress-percent">0%</span>
+                    {Array.from({ length: 10 }).map((_, index) => (
+                      <span key={index} className="stamp"></span>
+                    ))}
                   </td>
                   <td>
                     <button className="test-start-btn">

--- a/src/components/tests/test01/Test01Screen.tsx
+++ b/src/components/tests/test01/Test01Screen.tsx
@@ -4,6 +4,7 @@ import useAxios, { IRequestType, API_URL } from "@hooks/useAxios";
 import { useRecoilState } from "recoil";
 import { trainingData } from "@states/index";
 import PlaySound, { RES_URL } from "@hooks/PlaySound";
+import CustomInputButton from "../CustomInputButton";
 
 export default function Test01Screen() {
   const [isPlay, setIsPlay] = useState(false);
@@ -78,41 +79,31 @@ export default function Test01Screen() {
   return (
     <div className="test-screen-wrapper">
       {isPlay && (
-        <PlaySound
-          mp3={soundFile}
-          volume={100}
-          onEnd={() => setIsPlay(false)}
-        />
+        <PlaySound mp3={soundFile} volume={100} onEnd={() => setIsPlay(false)} />
       )}
       <div className="answer-buttons">
-        <button>
-          <img
-            src={`${process.env.PUBLIC_URL}/images/test/button_correct.png`}
-            alt="Correct answer button"
-          />
-        </button>
-        <button>
-          <img
-            src={`${process.env.PUBLIC_URL}/images/test/button_wrong.png`}
-            alt="Wrong answer button"
-          />
-        </button>
+        <CustomInputButton
+          type="radio"
+          id="correctButton"
+          name="answer"
+          imageName="button_correct"
+        />
+        <CustomInputButton
+          type="radio"
+          id="wrongButton"
+          name="answer"
+          imageName="button_wrong"
+        />
       </div>
       <div className="test-contents">
         <div className="navigation-buttons">
-          <button
-            onClick={showPrevQuiz}
-            className={quizIndex === 1 ? "disabled" : ""}
-          >
+          <button onClick={showPrevQuiz} className={quizIndex === 1 ? "disabled" : ""}>
             <img
               src={`${process.env.PUBLIC_URL}/images/test/button_left.png`}
               alt="Go to previous question"
             />
           </button>
-          <button
-            onClick={showNextQuiz}
-            className={quizIndex === 10 ? "disabled" : ""}
-          >
+          <button onClick={showNextQuiz} className={quizIndex === 10 ? "disabled" : ""}>
             <img
               src={`${process.env.PUBLIC_URL}/images/test/button_right.png`}
               alt="Go to next question"
@@ -135,9 +126,7 @@ export default function Test01Screen() {
                   style={{ width: "45px" }}
                 />
               )}
-              <p style={isPlay ? { color: "#fff" } : { color: "#63a4db" }}>
-                문장 듣기
-              </p>
+              <p style={isPlay ? { color: "#fff" } : { color: "#63a4db" }}>문장 듣기</p>
             </div>
           </div>
           <div className="view-sentence" onClick={toggleOpenAnswer}>
@@ -147,9 +136,7 @@ export default function Test01Screen() {
             />
             <p>정답 보기</p>
           </div>
-          <div
-            className={`view-sentence__accordion ${isOpenAnswer ? "open" : ""}`}
-          >
+          <div className={`view-sentence__accordion ${isOpenAnswer ? "open" : ""}`}>
             <img
               src={`${process.env.PUBLIC_URL}/images/test/answer.png`}
               alt="Sentence listening icon"

--- a/src/components/tests/test01/Test01Screen.tsx
+++ b/src/components/tests/test01/Test01Screen.tsx
@@ -2,9 +2,10 @@ import { useState, useEffect } from "react";
 import { useMatch, useParams } from "react-router-dom";
 import useAxios, { IRequestType, API_URL } from "@hooks/useAxios";
 import { useRecoilState } from "recoil";
-import { trainingData } from "@states/index";
+import { testModalState, trainingData } from "@states/index";
 import PlaySound, { RES_URL } from "@hooks/PlaySound";
-import CustomInputButton from "../CustomInputButton";
+import CustomInputButton from "@components/tests/CustomInputButton";
+import Modal from "@components/common/Modal";
 
 export default function Test01Screen() {
   const { level } = useParams();
@@ -14,6 +15,7 @@ export default function Test01Screen() {
   const [soundFile, setSoundFile] = useState<string>("");
   const [context, setContext] = useState<string>("");
   const [training, setTraining] = useRecoilState(trainingData);
+  const [testModal, setTestModal] = useRecoilState(testModalState);
 
   const match = useMatch("/training/part1/:level/:page/:quiz");
   // const soundFile = `${RES_URL}/function1/A01013.mp3`;
@@ -42,6 +44,12 @@ export default function Test01Screen() {
   };
 
   const res = useAxios(requestConfig);
+
+  useEffect(() => {
+    if (quizIndex === 10) {
+      setTestModal(true);
+    }
+  }, [quizIndex]);
 
   useEffect(() => {
     if (
@@ -78,6 +86,7 @@ export default function Test01Screen() {
 
   return (
     <div className="test-screen-wrapper">
+      {testModal && <Modal setModal={setTestModal} modalText="마지막 페이지입니다." />}
       {isPlay && (
         <PlaySound mp3={soundFile} volume={100} onEnd={() => setIsPlay(false)} />
       )}
@@ -87,20 +96,26 @@ export default function Test01Screen() {
             type="checkbox"
             id="withoutNoiseButton"
             name="answer"
+            className=""
             imageName="button_without_noise"
+            onClick={() => {}}
           />
         )}
         <CustomInputButton
           type="radio"
           id="correctButton"
           name="answer"
+          className=""
           imageName="button_correct"
+          onClick={() => {}}
         />
         <CustomInputButton
           type="radio"
           id="wrongButton"
           name="answer"
+          className=""
           imageName="button_wrong"
+          onClick={() => {}}
         />
       </div>
       <div className="test-contents">

--- a/src/components/tests/test01/Test01Screen.tsx
+++ b/src/components/tests/test01/Test01Screen.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { useMatch } from "react-router-dom";
+import { useMatch, useParams } from "react-router-dom";
 import useAxios, { IRequestType, API_URL } from "@hooks/useAxios";
 import { useRecoilState } from "recoil";
 import { trainingData } from "@states/index";
@@ -7,6 +7,7 @@ import PlaySound, { RES_URL } from "@hooks/PlaySound";
 import CustomInputButton from "../CustomInputButton";
 
 export default function Test01Screen() {
+  const { level } = useParams();
   const [isPlay, setIsPlay] = useState(false);
   const [isOpenAnswer, setIsOpenAnswer] = useState(false);
   const [quizIndex, setQuizIndex] = useState(1);
@@ -17,14 +18,13 @@ export default function Test01Screen() {
   const match = useMatch("/training/part1/:level/:page/:quiz");
   // const soundFile = `${RES_URL}/function1/A01013.mp3`;
 
-  let level: string | null = null;
   let page: string | null = null;
   let quiz: string | null = null;
   let currentPage: number | null = null;
   let currentQuiz: number | null = null;
 
   if (match) {
-    ({ level, page, quiz } = match.params as {
+    ({ page, quiz } = match.params as {
       level: string;
       page: string;
       quiz: string;
@@ -82,6 +82,14 @@ export default function Test01Screen() {
         <PlaySound mp3={soundFile} volume={100} onEnd={() => setIsPlay(false)} />
       )}
       <div className="answer-buttons">
+        {level !== "basic" && (
+          <CustomInputButton
+            type="radio"
+            id="withoutNoiseButton"
+            name="answer"
+            imageName="button_without_noise"
+          />
+        )}
         <CustomInputButton
           type="radio"
           id="correctButton"

--- a/src/components/tests/test01/Test01Screen.tsx
+++ b/src/components/tests/test01/Test01Screen.tsx
@@ -84,7 +84,7 @@ export default function Test01Screen() {
       <div className="answer-buttons">
         {level !== "basic" && (
           <CustomInputButton
-            type="radio"
+            type="checkbox"
             id="withoutNoiseButton"
             name="answer"
             imageName="button_without_noise"

--- a/src/components/tests/test02/Test02Screen.tsx
+++ b/src/components/tests/test02/Test02Screen.tsx
@@ -4,6 +4,7 @@ import { trainingData } from "@states/index";
 import { useEffect, useState } from "react";
 import { useMatch, useParams } from "react-router-dom";
 import { useRecoilState } from "recoil";
+import CustomInputButton from "../CustomInputButton";
 
 export default function Test02Screen() {
   const { level, page } = useParams<{ level: string; page?: string }>();
@@ -85,41 +86,31 @@ export default function Test02Screen() {
   return (
     <div className="test-screen-wrapper">
       {isPlay && (
-        <PlaySound
-          mp3={soundFile}
-          volume={100}
-          onEnd={() => setIsPlay(false)}
-        />
+        <PlaySound mp3={soundFile} volume={100} onEnd={() => setIsPlay(false)} />
       )}
       <div className="answer-buttons">
-        <button>
-          <img
-            src={`${process.env.PUBLIC_URL}/images/test/button_correct.png`}
-            alt="Correct answer button"
-          />
-        </button>
-        <button>
-          <img
-            src={`${process.env.PUBLIC_URL}/images/test/button_wrong.png`}
-            alt="Wrong answer button"
-          />
-        </button>
+        <CustomInputButton
+          type="radio"
+          id="correctButton"
+          name="answer"
+          imageName="button_correct"
+        />
+        <CustomInputButton
+          type="radio"
+          id="wrongButton"
+          name="answer"
+          imageName="button_wrong"
+        />
       </div>
       <div className="test-contents">
         <div className="navigation-buttons">
-          <button
-            onClick={showPrevQuiz}
-            className={quizIndex === 1 ? "disabled" : ""}
-          >
+          <button onClick={showPrevQuiz} className={quizIndex === 1 ? "disabled" : ""}>
             <img
               src={`${process.env.PUBLIC_URL}/images/test/button_left.png`}
               alt="Go to previous question"
             />
           </button>
-          <button
-            onClick={showNextQuiz}
-            className={quizIndex === 5 ? "disabled" : ""}
-          >
+          <button onClick={showNextQuiz} className={quizIndex === 5 ? "disabled" : ""}>
             <img
               src={`${process.env.PUBLIC_URL}/images/test/button_right.png`}
               alt="Go to next question"
@@ -157,9 +148,7 @@ export default function Test02Screen() {
               />
             </div>
           </div>
-          <div
-            className={`view-sentence__accordion ${isOpenText ? "open" : ""}`}
-          >
+          <div className={`view-sentence__accordion ${isOpenText ? "open" : ""}`}>
             <p className="describe-text">{context}</p>
           </div>
           <div className="view-sentence" onClick={toggleOpenAnswer}>
@@ -169,9 +158,7 @@ export default function Test02Screen() {
             />
             <p>정답 보기</p>
           </div>
-          <div
-            className={`view-sentence__accordion ${isOpenAnswer ? "open" : ""}`}
-          >
+          <div className={`view-sentence__accordion ${isOpenAnswer ? "open" : ""}`}>
             <img
               src={`${process.env.PUBLIC_URL}/images/test/answer.png`}
               alt="Sentence listening icon"

--- a/src/components/tests/test02/Test02Screen.tsx
+++ b/src/components/tests/test02/Test02Screen.tsx
@@ -1,10 +1,11 @@
 import PlaySound, { RES_URL } from "@hooks/PlaySound";
 import useAxios, { IRequestType, API_URL } from "@hooks/useAxios";
-import { trainingData } from "@states/index";
+import { testModalState, trainingData } from "@states/index";
 import { useEffect, useState } from "react";
 import { useMatch, useParams } from "react-router-dom";
 import { useRecoilState } from "recoil";
 import CustomInputButton from "../CustomInputButton";
+import Modal from "@components/common/Modal";
 
 export default function Test02Screen() {
   const { level, page } = useParams<{ level: string; page?: string }>();
@@ -16,6 +17,7 @@ export default function Test02Screen() {
   const [context, setContext] = useState<string>("");
   const [answer, setAnswer] = useState<string>("");
   const [training, setTraining] = useRecoilState(trainingData);
+  const [testModal, setTestModal] = useRecoilState(testModalState);
 
   const match = useMatch("/training/part2/:level/:page/:quiz");
 
@@ -37,6 +39,12 @@ export default function Test02Screen() {
   };
 
   const res = useAxios(requestConfig);
+
+  useEffect(() => {
+    if (quizIndex === 5) {
+      setTestModal(true);
+    }
+  }, [quizIndex]);
 
   useEffect(() => {
     if (
@@ -85,6 +93,7 @@ export default function Test02Screen() {
 
   return (
     <div className="test-screen-wrapper">
+      {testModal && <Modal setModal={setTestModal} modalText="마지막 페이지입니다." />}
       {isPlay && (
         <PlaySound mp3={soundFile} volume={100} onEnd={() => setIsPlay(false)} />
       )}
@@ -93,13 +102,17 @@ export default function Test02Screen() {
           type="radio"
           id="correctButton"
           name="answer"
+          className=""
           imageName="button_correct"
+          onClick={() => {}}
         />
         <CustomInputButton
           type="radio"
           id="wrongButton"
           name="answer"
+          className=""
           imageName="button_wrong"
+          onClick={() => {}}
         />
       </div>
       <div className="test-contents">

--- a/src/components/tests/test03/Test03Screen.tsx
+++ b/src/components/tests/test03/Test03Screen.tsx
@@ -1,12 +1,15 @@
+import Modal from "@components/common/Modal";
 import PlaySound, { RES_URL } from "@hooks/PlaySound";
 import useAxios, { IRequestType, API_URL } from "@hooks/useAxios";
-import { trainingData } from "@states/index";
+import { testModalState, trainingData } from "@states/index";
 import { ChangeEvent, useEffect, useState } from "react";
-import { Link, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router-dom";
 import { useRecoilState } from "recoil";
+import CustomInputButton from "../CustomInputButton";
 
 export default function Test03Screen() {
   const { level, page } = useParams<{ level: string; page?: string }>();
+  const navigate = useNavigate();
   const [isPlay, setIsPlay] = useState(false);
   const [isViewStory, setIsViewStory] = useState(false);
   const [isViewQuestion, setIsViewQuestion] = useState(false);
@@ -17,6 +20,7 @@ export default function Test03Screen() {
   const [context, setContext] = useState<string>("");
   // const [answer, setAnswer] = useState<string>("");
   const [training, setTraining] = useRecoilState(trainingData);
+  const [testModal, setTestModal] = useRecoilState(testModalState);
 
   console.log("training", training);
 
@@ -71,9 +75,14 @@ export default function Test03Screen() {
       setQnaCount(qnaCount + 1);
     }
   };
+  const handleNavigate = () => {
+    setTestModal(true);
+    navigate("/home");
+  };
 
   return (
     <div className="test-screen-wrapper">
+      {testModal && <Modal setModal={setTestModal} modalText="훈련을 마쳤습니다." />}
       {isPlay && (
         <PlaySound mp3={soundFile} volume={100} onEnd={() => setIsPlay(false)} />
       )}
@@ -91,27 +100,30 @@ export default function Test03Screen() {
             />
           )}
         </button>
-        <button className="answer-buttons__opacity_1" onClick={toggleViewStory}>
-          <img
-            className="answer-buttons__opacity_1"
-            src={`${process.env.PUBLIC_URL}/images/test/button_view_story.png`}
-            alt="View story button"
-          />
-        </button>
-        <button className="answer-buttons__opacity_1" onClick={toggleViewQuestion}>
-          <img
-            className="answer-buttons__opacity_1"
-            src={`${process.env.PUBLIC_URL}/images/test/button_view_question.png`}
-            alt="View question button"
-          />
-        </button>
-        <Link to="/home" className="answer-buttons__opacity_1">
-          <img
-            className="answer-buttons__opacity_1"
-            src={`${process.env.PUBLIC_URL}/images/test/button_submit.png`}
-            alt="Submit button"
-          />
-        </Link>
+        <CustomInputButton
+          type="radio"
+          id="viewStoryButton"
+          name="viewStory"
+          className="answer-buttons__opacity_1"
+          imageName="button_view_story"
+          onClick={toggleViewStory}
+        />
+        <CustomInputButton
+          type="radio"
+          id="viewQuestionButton"
+          name="viewQuestion"
+          className="answer-buttons__opacity_1"
+          imageName="button_view_question"
+          onClick={toggleViewQuestion}
+        />
+        <CustomInputButton
+          type="radio"
+          id="submitButton"
+          name="submit"
+          className="answer-buttons__opacity_1"
+          imageName="button_submit"
+          onClick={() => setTestModal(true)}
+        />
       </div>
       <div className="test-contents test-contents__width-full">
         {!isViewStory && !isViewQuestion && (

--- a/src/components/tests/test04/Test04Screen.tsx
+++ b/src/components/tests/test04/Test04Screen.tsx
@@ -49,18 +49,26 @@ export default function Test04Screen() {
   }, [level]);
 
   // 문장을 섞어서 렌더링하기 위한 shuffle 메서드
-  const shuffle = (array: QuizItem[]) => {
-    let currentIndex = array.length,
-      randomIndex;
+  const shuffle = (array: QuizItem[], correctOrder: number[]) => {
+    let shuffled = false;
 
-    while (currentIndex !== 0) {
-      randomIndex = Math.floor(Math.random() * currentIndex);
-      currentIndex--;
+    while (!shuffled) {
+      let currentIndex = array.length,
+        randomIndex;
 
-      [array[currentIndex], array[randomIndex]] = [
-        array[randomIndex],
-        array[currentIndex],
-      ];
+      while (currentIndex !== 0) {
+        randomIndex = Math.floor(Math.random() * currentIndex);
+        currentIndex--;
+        [array[currentIndex], array[randomIndex]] = [
+          array[randomIndex],
+          array[currentIndex],
+        ];
+      }
+
+      // Shuffle된 결과가 정답 순서와 동일한지 확인
+      if (!array.every((item, index) => correctOrder[index] === item.id)) {
+        shuffled = true;
+      }
     }
 
     return array;
@@ -68,7 +76,8 @@ export default function Test04Screen() {
 
   useEffect(() => {
     setQuizItems((currentItems) => {
-      const shuffledItems = shuffle([...currentItems]);
+      const correctOrder = determineCorrectOrder();
+      const shuffledItems = shuffle([...currentItems], correctOrder);
       checkOrder(shuffledItems);
       return shuffledItems;
     });

--- a/src/components/tests/test04/Test04Screen.tsx
+++ b/src/components/tests/test04/Test04Screen.tsx
@@ -1,7 +1,10 @@
+import Modal from "@components/common/Modal";
+import { testModalState } from "@states/index";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { DndProvider, useDrag, useDrop } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 import { useParams } from "react-router-dom";
+import { useRecoilState } from "recoil";
 
 type QuizItem = {
   id: number;
@@ -13,6 +16,7 @@ export default function Test04Screen() {
   const [isPlay, setIsPlay] = useState([false]);
   const [sequencing, setSequencing] = useState(false);
   const [isOpenAnswer, setIsOpenAnswer] = useState(false);
+  const [testModal, setTestModal] = useRecoilState(testModalState);
 
   const { level } = useParams();
   const count = parseInt(level?.charAt(level.length - 1) ?? "0", 10);
@@ -157,6 +161,7 @@ export default function Test04Screen() {
   return (
     <DndProvider backend={HTML5Backend}>
       <div className="test-screen-wrapper__main">
+        {testModal && <Modal setModal={setTestModal} modalText="훈련을 마쳤습니다." />}
         <div className="answer-buttons">
           <button
             onClick={toggleSequencing}
@@ -187,7 +192,7 @@ export default function Test04Screen() {
                   alt="Wrong answer button"
                 />
               </button>
-              <button style={{ opacity: 1 }}>
+              <button style={{ opacity: 1 }} onClick={() => setTestModal(true)}>
                 <img
                   src={`${process.env.PUBLIC_URL}/images/test/button_next_quiz.png`}
                   alt="Go to next quiz button"

--- a/src/components/tests/test04/Test04Screen.tsx
+++ b/src/components/tests/test04/Test04Screen.tsx
@@ -69,10 +69,8 @@ export default function Test04Screen() {
         ];
       }
 
-      // Shuffle된 결과가 정답 순서와 동일한지 확인
-      if (!array.every((item, index) => correctOrder[index] === item.id)) {
-        shuffled = true;
-      }
+      // 모든 요소가 정답 순서와 다른지 확인
+      shuffled = array.every((item, index) => correctOrder[index] !== item.id);
     }
 
     return array;
@@ -150,10 +148,10 @@ export default function Test04Screen() {
     </li>
   ));
 
-  const answerListItems = Array.from({ length: count }, (_, index) => (
+  const answerListItems = determineCorrectOrder().map((order, index) => (
     <li key={index} className="test-screen__sequencing-item">
       <p>
-        {index + 1}. 문장 순서화 하기 {index + 1}번 정답
+        {index + 1}. 문장 순서화 하기 {order + 1}번 정답
       </p>
     </li>
   ));

--- a/src/components/tests/test04/Test04Screen.tsx
+++ b/src/components/tests/test04/Test04Screen.tsx
@@ -1,4 +1,6 @@
-import { useState } from "react";
+import { useCallback, useRef, useState } from "react";
+import { DndProvider, useDrag, useDrop } from "react-dnd";
+import { HTML5Backend } from "react-dnd-html5-backend";
 import { useParams } from "react-router-dom";
 
 export default function Test04Screen() {
@@ -8,6 +10,26 @@ export default function Test04Screen() {
 
   const { level } = useParams();
   const count = parseInt(level?.charAt(level.length - 1) ?? "0", 10);
+
+  const [quizItems, setQuizItems] = useState(
+    Array.from({ length: count }, (_, index) => ({
+      id: index,
+      text: `문장 순서화 하기 ${index + 1}번 문제`,
+    }))
+  );
+
+  const moveItem = useCallback(
+    (dragIndex: any, hoverIndex: any) => {
+      const dragItem = quizItems[dragIndex];
+      setQuizItems((prevItems) => {
+        const newItems = [...prevItems];
+        newItems.splice(dragIndex, 1);
+        newItems.splice(hoverIndex, 0, dragItem);
+        return newItems;
+      });
+    },
+    [quizItems]
+  );
 
   const togglePlay = (index: number) => {
     const updatedIsPlay = isPlay.map(() => false);
@@ -63,61 +85,128 @@ export default function Test04Screen() {
   ));
 
   return (
-    <div className="test-screen-wrapper__main">
-      <div className="answer-buttons">
-        <button
-          onClick={toggleSequencing}
-          style={sequencing ? { display: "none" } : { opacity: 1 }}
-        >
-          <img
-            src={`${process.env.PUBLIC_URL}/images/test/button_sequencing.png`}
-            alt="Sequencing button"
-          />
-        </button>
-        {sequencing && (
-          <div className="answer-buttons__sequencing">
-            <button style={{ opacity: 1 }} onClick={toggleOpenAnswer}>
-              <img
-                src={`${process.env.PUBLIC_URL}/images/test/show_answer.png`}
-                alt="Show answer button"
-              />
-            </button>
-            <button>
-              <img
-                src={`${process.env.PUBLIC_URL}/images/test/button_correct.png`}
-                alt="Correct answer button"
-              />
-            </button>
-            <button>
-              <img
-                src={`${process.env.PUBLIC_URL}/images/test/button_wrong.png`}
-                alt="Wrong answer button"
-              />
-            </button>
-            <button style={{ opacity: 1 }}>
-              <img
-                src={`${process.env.PUBLIC_URL}/images/test/button_next_quiz.png`}
-                alt="Go to next quiz button"
-              />
-            </button>
-          </div>
-        )}
+    <DndProvider backend={HTML5Backend}>
+      <div className="test-screen-wrapper__main">
+        <div className="answer-buttons">
+          <button
+            onClick={toggleSequencing}
+            style={sequencing ? { display: "none" } : { opacity: 1 }}
+          >
+            <img
+              src={`${process.env.PUBLIC_URL}/images/test/button_sequencing.png`}
+              alt="Sequencing button"
+            />
+          </button>
+          {sequencing && (
+            <div className="answer-buttons__sequencing">
+              <button style={{ opacity: 1 }} onClick={toggleOpenAnswer}>
+                <img
+                  src={`${process.env.PUBLIC_URL}/images/test/show_answer.png`}
+                  alt="Show answer button"
+                />
+              </button>
+              <button>
+                <img
+                  src={`${process.env.PUBLIC_URL}/images/test/button_correct.png`}
+                  alt="Correct answer button"
+                />
+              </button>
+              <button>
+                <img
+                  src={`${process.env.PUBLIC_URL}/images/test/button_wrong.png`}
+                  alt="Wrong answer button"
+                />
+              </button>
+              <button style={{ opacity: 1 }}>
+                <img
+                  src={`${process.env.PUBLIC_URL}/images/test/button_next_quiz.png`}
+                  alt="Go to next quiz button"
+                />
+              </button>
+            </div>
+          )}
+        </div>
+        <div className="test-screen__content">
+          {sequencing ? (
+            <div className="test-screen__select">
+              {isOpenAnswer ? (
+                <ul className="test-screen__select-list">{answerListItems}</ul>
+              ) : (
+                <DropList items={quizItems} moveItem={moveItem} />
+              )}
+            </div>
+          ) : (
+            <div className="test-screen__select">
+              <ul className="test-screen__select-list">{listItems}</ul>
+            </div>
+          )}
+        </div>
       </div>
-      <div className="test-screen__content">
-        {sequencing ? (
-          <div className="test-screen__select">
-            {isOpenAnswer ? (
-              <ul className="test-screen__select-list">{answerListItems}</ul>
-            ) : (
-              <ul className="test-screen__select-list">{quizListItems}</ul>
-            )}
-          </div>
-        ) : (
-          <div className="test-screen__select">
-            <ul className="test-screen__select-list">{listItems}</ul>
-          </div>
-        )}
-      </div>
-    </div>
+    </DndProvider>
   );
 }
+
+const DraggableItem = ({ id, text }: { id: number; text: string }) => {
+  const [, drag] = useDrag(() => ({
+    type: "QUIZ_ITEM",
+    item: { id },
+  }));
+
+  return (
+    <li ref={drag} className="test-screen__sequencing-item">
+      {`${id + 1}. ${text}`}
+    </li>
+  );
+};
+
+const DropList = ({ items, moveItem }: { items: any[]; moveItem: Function }) => {
+  const ref = useRef<HTMLUListElement>(null);
+  const [, drop] = useDrop({
+    accept: "QUIZ_ITEM",
+    hover(item: { id: number }, monitor) {
+      if (!ref.current) {
+        return;
+      }
+
+      const dragIndex = items.findIndex((i) => i.id === item.id);
+      const clientOffset = monitor.getClientOffset();
+
+      if (!clientOffset) {
+        return;
+      }
+
+      const hoverClientY = clientOffset.y;
+      let hoverIndex = -1;
+      const children = Array.from(ref.current.children);
+
+      for (let i = 0; i < children.length; i++) {
+        const child = children[i] as HTMLElement;
+        const childRect = child.getBoundingClientRect();
+        const childMiddleY = (childRect.top + childRect.bottom) / 2;
+
+        if (hoverClientY < childMiddleY) {
+          hoverIndex = i;
+          break;
+        }
+      }
+
+      if (hoverIndex === -1) {
+        hoverIndex = children.length - 1;
+      }
+
+      if (dragIndex !== hoverIndex) {
+        moveItem(dragIndex, hoverIndex);
+      }
+    },
+  });
+
+  drop(ref);
+
+  return (
+    <ul ref={ref}>
+      {items.map((item, index) => (
+        <DraggableItem key={item.id} id={index} text={item.text} />
+      ))}
+    </ul>
+  );
+};

--- a/src/components/tests/test05/CrosswordGrid.tsx
+++ b/src/components/tests/test05/CrosswordGrid.tsx
@@ -7,6 +7,7 @@ interface CrosswordGridProps {
   disabledCells: Array<{ row: number; col: number }>;
   horizontalHints: Array<{ number: number; row: number; col: number }>;
   verticalHints: Array<{ number: number; row: number; col: number }>;
+  answers: { [key: string]: string };
 }
 interface HintGridProps {
   rows: number;
@@ -24,32 +25,38 @@ export default function CrosswordGrid({
   disabledCells,
   horizontalHints,
   verticalHints,
+  answers,
 }: CrosswordGridProps) {
   const gridRows = Array.from({ length: rows }, (_, rowIndex) => (
     <tr key={rowIndex} style={{ height: `${462 / rows}px` }}>
-      {Array.from({ length: columns }, (_, colIndex) => (
-        <td
-          className="crossword-answer-input"
-          key={colIndex}
-          style={{ height: `${462 / rows}px` }}
-        >
-          <div className="hint-container">
-            <p className="horizontal-hint">
-              {renderHintNumber(rowIndex, colIndex, horizontalHints)}
-            </p>
-            <p className="vertical-hint">
-              {renderHintNumber(rowIndex, colIndex, verticalHints)}
-            </p>
-          </div>
+      {Array.from({ length: columns }, (_, colIndex) => {
+        const answerKey = `${rowIndex}_${colIndex}`;
+        return (
+          <td
+            className="crossword-answer-input"
+            key={colIndex}
+            style={{ height: `${462 / rows}px` }}
+          >
+            <div className="hint-container">
+              <p className="horizontal-hint">
+                {renderHintNumber(rowIndex, colIndex, horizontalHints)}
+              </p>
+              <p className="vertical-hint">
+                {renderHintNumber(rowIndex, colIndex, verticalHints)}
+              </p>
+            </div>
 
-          <input
-            type="text"
-            placeholder=""
-            maxLength={1}
-            disabled={isCellDisabled({ rowIndex, colIndex, disabledCells })}
-          />
-        </td>
-      ))}
+            <input
+              type="text"
+              placeholder=""
+              maxLength={1}
+              value={answers && answers[answerKey] ? answers[answerKey] : ""}
+              disabled={isCellDisabled({ rowIndex, colIndex, disabledCells })}
+              readOnly
+            />
+          </td>
+        );
+      })}
     </tr>
   ));
 

--- a/src/components/tests/test05/CrosswordGrid.tsx
+++ b/src/components/tests/test05/CrosswordGrid.tsx
@@ -1,3 +1,5 @@
+import { ChangeEvent, useState } from "react";
+
 interface CrosswordGridProps {
   rows: number;
   columns: number;
@@ -15,76 +17,7 @@ interface DisabledCellProps {
   disabledCells: Array<{ row: number; col: number }>;
 }
 
-function HintGrid({ rows }: HintGridProps) {
-  const headers = [" ", "Level 1", "Level 2", "Level 3", "정답", "채점"];
-  const hintTitle = Array.from(
-    { length: rows },
-    (_, index) => `${index + 1}번\n힌트`
-  );
-
-  return (
-    <table className="hint-grid">
-      <thead>
-        <tr className="blue">
-          {headers.map((header, index) => (
-            <th key={index} style={{ width: `calc(100% / 6)` }}>
-              {header}
-            </th>
-          ))}
-        </tr>
-      </thead>
-      <tbody>
-        {hintTitle.map((title, rowIndex) => (
-          <tr key={rowIndex}>
-            <td className="blue">{title}</td>
-            {Array.from({ length: 5 }, (_, colIndex) => (
-              <td key={colIndex}>
-                {colIndex < 4 ? (
-                  <button>
-                    <img
-                      src={`${process.env.PUBLIC_URL}/images/test/play_small.png`}
-                      alt="Play Button"
-                    />
-                  </button>
-                ) : (
-                  <ul className="scoring">
-                    <li className="check-correct">
-                      <button>O</button>
-                    </li>
-                    <li className="check-wrong">
-                      <button>X</button>
-                    </li>
-                  </ul>
-                )}
-              </td>
-            ))}
-          </tr>
-        ))}
-      </tbody>
-    </table>
-  );
-}
-
-function isCellDisabled({
-  rowIndex,
-  colIndex,
-  disabledCells,
-}: DisabledCellProps) {
-  return disabledCells.some(
-    (cell) => cell.row === rowIndex && cell.col === colIndex
-  );
-}
-
-function renderHintNumber(
-  row: number,
-  col: number,
-  hints: Array<{ number: number; row: number; col: number }>
-) {
-  const hint = hints.find((h) => h.row === row && h.col === col);
-  return hint ? hint.number : null;
-}
-
-function CrosswordGrid({
+export default function CrosswordGrid({
   rows,
   columns,
   hintRows,
@@ -92,20 +25,6 @@ function CrosswordGrid({
   horizontalHints,
   verticalHints,
 }: CrosswordGridProps) {
-  // disabledCells 유효성 검사
-  disabledCells.forEach((cell) => {
-    if (
-      cell.row >= rows ||
-      cell.col >= columns ||
-      cell.row < 0 ||
-      cell.col < 0
-    ) {
-      throw new Error(
-        `유효하지 않은 셀 위치: (${cell.row}, ${cell.col}). 그리드 내에 있어야 합니다.`
-      );
-    }
-  });
-
   const gridRows = Array.from({ length: rows }, (_, rowIndex) => (
     <tr key={rowIndex} style={{ height: `${462 / rows}px` }}>
       {Array.from({ length: columns }, (_, colIndex) => (
@@ -144,4 +63,95 @@ function CrosswordGrid({
   );
 }
 
-export default CrosswordGrid;
+function HintGrid({ rows }: HintGridProps) {
+  const headers = [" ", "Level 1", "Level 2", "Level 3", "정답", "채점"];
+  const hintTitle = Array.from({ length: rows }, (_, index) => `${index + 1}번\n힌트`);
+  const [selectedOptions, setSelectedOptions] = useState<Array<string>>(
+    Array(rows).fill("")
+  );
+
+  const handleRadioChange = (rowIndex: number) => (e: ChangeEvent<HTMLInputElement>) => {
+    const newSelectedOptions = [...selectedOptions];
+    newSelectedOptions[rowIndex] = e.target.value;
+    setSelectedOptions(newSelectedOptions);
+  };
+
+  return (
+    <table className="hint-grid">
+      <thead>
+        <tr className="blue">
+          {headers.map((header, index) => (
+            <th key={index} style={{ width: `calc(100% / 6)` }}>
+              {header}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {hintTitle.map((title, rowIndex) => (
+          <tr key={rowIndex}>
+            <td className="blue">{title}</td>
+            {Array.from({ length: 5 }, (_, colIndex) => (
+              <td key={colIndex}>
+                {colIndex < 4 ? (
+                  <button>
+                    <img
+                      src={`${process.env.PUBLIC_URL}/images/test/play_small.png`}
+                      alt="Play Button"
+                    />
+                  </button>
+                ) : (
+                  <ul className="scoring">
+                    <li
+                      className={`check-correct ${
+                        selectedOptions[rowIndex] === "correct" ? "active" : ""
+                      }`}
+                    >
+                      <input
+                        type="radio"
+                        id={`score-correct-${rowIndex}`}
+                        name={`score-${rowIndex}`}
+                        value="correct"
+                        onChange={handleRadioChange(rowIndex)}
+                        hidden
+                      />
+                      <label htmlFor={`score-correct-${rowIndex}`}>O</label>
+                    </li>
+                    <li
+                      className={`check-wrong ${
+                        selectedOptions[rowIndex] === "wrong" ? "active" : ""
+                      }`}
+                    >
+                      <input
+                        type="radio"
+                        id={`score-wrong-${rowIndex}`}
+                        name={`score-${rowIndex}`}
+                        value="wrong"
+                        onChange={handleRadioChange(rowIndex)}
+                        hidden
+                      />
+                      <label htmlFor={`score-wrong-${rowIndex}`}>X</label>
+                    </li>
+                  </ul>
+                )}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function isCellDisabled({ rowIndex, colIndex, disabledCells }: DisabledCellProps) {
+  return disabledCells.some((cell) => cell.row === rowIndex && cell.col === colIndex);
+}
+
+function renderHintNumber(
+  row: number,
+  col: number,
+  hints: Array<{ number: number; row: number; col: number }>
+) {
+  const hint = hints.find((h) => h.row === row && h.col === col);
+  return hint ? hint.number : null;
+}

--- a/src/data/crosswordData.json
+++ b/src/data/crosswordData.json
@@ -17,7 +17,17 @@
     "verticalHints": [
       { "number": 2, "row": 0, "col": 1 },
       { "number": 3, "row": 2, "col": 2 }
-    ]
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
   },
   {
     "quiz": 2,
@@ -26,478 +36,2967 @@
     "hintRows": 4,
     "disabledCells": [
       { "row": 1, "col": 0 },
-      { "row": 1, "col": 1 },
-      { "row": 2, "col": 0 },
-      { "row": 2, "col": 2 }
-    ],
-    "horizontalHints": [
-      { "number": 1, "row": 0, "col": 0 },
-      { "number": 3, "row": 3, "col": 0 }
-    ],
-    "verticalHints": [
-      { "number": 2, "row": 0, "col": 2 },
-      { "number": 4, "row": 2, "col": 1 }
-    ]
-  },
-  {
-    "quiz": 3,
-    "rows": 3,
-    "columns": 5,
-    "hintRows": 4,
-    "disabledCells": [
-      { "row": 0, "col": 3 },
-      { "row": 0, "col": 4 },
-      { "row": 1, "col": 0 },
       { "row": 1, "col": 2 },
-      { "row": 1, "col": 3 },
-      { "row": 2, "col": 0 }
-    ],
-    "horizontalHints": [
-      { "number": 1, "row": 0, "col": 0 },
-      { "number": 3, "row": 2, "col": 1 }
-    ],
-    "verticalHints": [
-      { "number": 2, "row": 0, "col": 1 },
-      { "number": 4, "row": 1, "col": 4 }
-    ]
-  },
-  {
-    "quiz": 4,
-    "rows": 4,
-    "columns": 4,
-    "hintRows": 4,
-    "disabledCells": [
-      { "row": 0, "col": 3 },
-      { "row": 0, "col": 1 },
-      { "row": 2, "col": 1 },
-      { "row": 2, "col": 2 },
-      { "row": 3, "col": 0 },
-      { "row": 3, "col": 1 },
-      { "row": 3, "col": 2 }
-    ],
-    "horizontalHints": [{ "number": 2, "row": 1, "col": 0 }],
-    "verticalHints": [
-      { "number": 1, "row": 0, "col": 0 },
-      { "number": 3, "row": 0, "col": 2 },
-      { "number": 4, "row": 1, "col": 3 }
-    ]
-  },
-  {
-    "quiz": 5,
-    "rows": 4,
-    "columns": 5,
-    "hintRows": 4,
-    "disabledCells": [
-      { "row": 0, "col": 0 },
-      { "row": 0, "col": 1 },
-      { "row": 0, "col": 2 },
-      { "row": 1, "col": 0 },
-      { "row": 1, "col": 1 },
-      { "row": 1, "col": 2 },
-      { "row": 1, "col": 4 },
-      { "row": 2, "col": 4 },
-      { "row": 3, "col": 0 },
-      { "row": 3, "col": 2 },
-      { "row": 3, "col": 3 },
-      { "row": 3, "col": 4 }
-    ],
-    "horizontalHints": [
-      { "number": 1, "row": 0, "col": 3 },
-      { "number": 3, "row": 2, "col": 0 }
-    ],
-    "verticalHints": [
-      { "number": 2, "row": 0, "col": 3 },
-      { "number": 4, "row": 2, "col": 1 }
-    ]
-  },
-  {
-    "quiz": 6,
-    "rows": 3,
-    "columns": 5,
-    "hintRows": 4,
-    "disabledCells": [
-      { "row": 0, "col": 2 },
-      { "row": 0, "col": 3 },
-      { "row": 0, "col": 4 },
-      { "row": 1, "col": 0 },
-      { "row": 1, "col": 2 },
-      { "row": 2, "col": 0 },
-      { "row": 2, "col": 2 },
-      { "row": 2, "col": 3 }
-    ],
-    "horizontalHints": [
-      { "number": 1, "row": 0, "col": 0 },
-      { "number": 3, "row": 1, "col": 3 }
-    ],
-    "verticalHints": [
-      { "number": 2, "row": 0, "col": 1 },
-      { "number": 4, "row": 1, "col": 4 }
-    ]
-  },
-  {
-    "quiz": 7,
-    "rows": 4,
-    "columns": 4,
-    "hintRows": 4,
-    "disabledCells": [
-      { "row": 0, "col": 0 },
-      { "row": 0, "col": 1 },
-      { "row": 1, "col": 3 },
-      { "row": 2, "col": 0 },
-      { "row": 2, "col": 1 },
-      { "row": 3, "col": 0 },
-      { "row": 3, "col": 1 },
-      { "row": 3, "col": 3 }
-    ],
-    "horizontalHints": [
-      { "number": 1, "row": 0, "col": 2 },
-      { "number": 3, "row": 1, "col": 0 },
-      { "number": 4, "row": 2, "col": 2 }
-    ],
-    "verticalHints": [{ "number": 2, "row": 0, "col": 2 }]
-  },
-  {
-    "quiz": 8,
-    "rows": 5,
-    "columns": 5,
-    "hintRows": 4,
-    "disabledCells": [
-      { "row": 0, "col": 0 },
-      { "row": 0, "col": 1 },
-      { "row": 0, "col": 3 },
-      { "row": 0, "col": 4 },
-      { "row": 1, "col": 3 },
-      { "row": 1, "col": 4 },
-      { "row": 2, "col": 0 },
-      { "row": 2, "col": 1 },
-      { "row": 2, "col": 3 },
-      { "row": 3, "col": 0 },
-      { "row": 3, "col": 1 },
-      { "row": 4, "col": 0 },
-      { "row": 4, "col": 1 },
-      { "row": 4, "col": 2 },
-      { "row": 4, "col": 3 }
-    ],
-    "horizontalHints": [
-      { "number": 1, "row": 1, "col": 0 },
-      { "number": 3, "row": 3, "col": 2 }
-    ],
-    "verticalHints": [
-      { "number": 2, "row": 0, "col": 2 },
-      { "number": 4, "row": 2, "col": 4 }
-    ]
-  },
-  {
-    "quiz": 9,
-    "rows": 5,
-    "columns": 4,
-    "hintRows": 4,
-    "disabledCells": [
-      { "row": 0, "col": 0 },
-      { "row": 0, "col": 1 },
-      { "row": 0, "col": 3 },
-      { "row": 1, "col": 0 },
-      { "row": 1, "col": 1 },
-      { "row": 2, "col": 3 },
-      { "row": 3, "col": 1 },
-      { "row": 3, "col": 2 },
-      { "row": 3, "col": 3 },
-      { "row": 4, "col": 1 },
-      { "row": 4, "col": 2 },
-      { "row": 4, "col": 3 }
-    ],
-    "horizontalHints": [
-      { "number": 2, "row": 1, "col": 2 },
-      { "number": 3, "row": 2, "col": 0 }
-    ],
-    "verticalHints": [
-      { "number": 1, "row": 0, "col": 2 },
-      { "number": 4, "row": 2, "col": 0 }
-    ]
-  },
-  {
-    "quiz": 10,
-    "rows": 5,
-    "columns": 4,
-    "hintRows": 4,
-    "disabledCells": [
-      { "row": 0, "col": 2 },
-      { "row": 0, "col": 3 },
-      { "row": 1, "col": 0 },
-      { "row": 2, "col": 0 },
-      { "row": 2, "col": 1 },
-      { "row": 2, "col": 3 },
-      { "row": 3, "col": 0 },
-      { "row": 3, "col": 1 },
-      { "row": 3, "col": 3 },
-      { "row": 4, "col": 0 },
-      { "row": 4, "col": 1 },
-      { "row": 4, "col": 3 }
-    ],
-    "horizontalHints": [
-      { "number": 1, "row": 0, "col": 0 },
-      { "number": 3, "row": 1, "col": 1 }
-    ],
-    "verticalHints": [
-      { "number": 2, "row": 0, "col": 1 },
-      { "number": 4, "row": 1, "col": 2 }
-    ]
-  },
-  {
-    "quiz": 11,
-    "rows": 3,
-    "columns": 4,
-    "hintRows": 4,
-    "disabledCells": [
-      { "row": 0, "col": 2 },
-      { "row": 0, "col": 3 },
-      { "row": 1, "col": 0 },
-      { "row": 2, "col": 0 },
-      { "row": 2, "col": 1 },
-      { "row": 2, "col": 2 }
-    ],
-    "horizontalHints": [
-      { "number": 1, "row": 0, "col": 0 },
-      { "number": 3, "row": 1, "col": 1 }
-    ],
-    "verticalHints": [
-      { "number": 2, "row": 0, "col": 1 },
-      { "number": 4, "row": 1, "col": 3 }
-    ]
-  },
-  {
-    "quiz": 12,
-    "rows": 5,
-    "columns": 4,
-    "hintRows": 4,
-    "disabledCells": [
-      { "row": 0, "col": 3 },
-      { "row": 1, "col": 0 },
-      { "row": 1, "col": 2 },
-      { "row": 1, "col": 3 },
-      { "row": 2, "col": 0 },
-      { "row": 3, "col": 0 },
-      { "row": 3, "col": 1 },
-      { "row": 3, "col": 3 },
-      { "row": 4, "col": 0 },
-      { "row": 4, "col": 1 },
-      { "row": 4, "col": 3 }
-    ],
-    "horizontalHints": [
-      { "number": 1, "row": 0, "col": 0 },
-      { "number": 3, "row": 2, "col": 1 }
-    ],
-    "verticalHints": [
-      { "number": 2, "row": 0, "col": 1 },
-      { "number": 4, "row": 2, "col": 2 }
-    ]
-  },
-  {
-    "quiz": 13,
-    "rows": 6,
-    "columns": 5,
-    "hintRows": 4,
-    "disabledCells": [
-      { "row": 0, "col": 0 },
-      { "row": 0, "col": 2 },
-      { "row": 0, "col": 3 },
-      { "row": 0, "col": 4 },
-      { "row": 1, "col": 0 },
-      { "row": 1, "col": 2 },
-      { "row": 1, "col": 3 },
-      { "row": 1, "col": 4 },
-      { "row": 2, "col": 3 },
-      { "row": 3, "col": 0 },
-      { "row": 3, "col": 1 },
-      { "row": 3, "col": 2 },
-      { "row": 3, "col": 3 },
-      { "row": 4, "col": 0 },
-      { "row": 4, "col": 1 },
-      { "row": 5, "col": 0 },
-      { "row": 5, "col": 1 },
-      { "row": 5, "col": 2 },
-      { "row": 5, "col": 3 }
-    ],
-    "horizontalHints": [
-      { "number": 2, "row": 2, "col": 0 },
-      { "number": 4, "row": 4, "col": 2 }
-    ],
-    "verticalHints": [
-      { "number": 1, "row": 0, "col": 1 },
-      { "number": 3, "row": 2, "col": 4 }
-    ]
-  },
-  {
-    "quiz": 14,
-    "rows": 5,
-    "columns": 4,
-    "hintRows": 4,
-    "disabledCells": [
-      { "row": 0, "col": 1 },
-      { "row": 0, "col": 2 },
-      { "row": 0, "col": 3 },
-      { "row": 1, "col": 2 },
-      { "row": 1, "col": 3 },
-      { "row": 2, "col": 1 },
-      { "row": 2, "col": 2 },
-      { "row": 3, "col": 0 },
-      { "row": 3, "col": 1 },
-      { "row": 3, "col": 2 },
-      { "row": 4, "col": 0 }
-    ],
-    "horizontalHints": [
-      { "number": 2, "row": 1, "col": 0 },
-      { "number": 4, "row": 4, "col": 1 }
-    ],
-    "verticalHints": [
-      { "number": 1, "row": 0, "col": 0 },
-      { "number": 3, "row": 2, "col": 3 }
-    ]
-  },
-  {
-    "quiz": 15,
-    "rows": 4,
-    "columns": 5,
-    "hintRows": 4,
-    "disabledCells": [
-      { "row": 0, "col": 4 },
-      { "row": 1, "col": 0 },
-      { "row": 1, "col": 1 },
-      { "row": 1, "col": 3 },
-      { "row": 2, "col": 0 },
-      { "row": 2, "col": 1 },
-      { "row": 2, "col": 2 },
-      { "row": 2, "col": 3 },
-      { "row": 3, "col": 0 },
-      { "row": 3, "col": 1 }
-    ],
-    "horizontalHints": [
-      { "number": 1, "row": 0, "col": 0 },
-      { "number": 4, "row": 3, "col": 2 }
-    ],
-    "verticalHints": [
-      { "number": 2, "row": 0, "col": 2 },
-      { "number": 3, "row": 1, "col": 4 }
-    ]
-  },
-  {
-    "quiz": 16,
-    "rows": 4,
-    "columns": 4,
-    "hintRows": 4,
-    "disabledCells": [
-      { "row": 0, "col": 3 },
-      { "row": 1, "col": 0 },
-      { "row": 1, "col": 2 },
-      { "row": 1, "col": 3 },
-      { "row": 2, "col": 0 },
-      { "row": 2, "col": 1 },
-      { "row": 2, "col": 2 },
-      { "row": 3, "col": 0 }
-    ],
-    "horizontalHints": [
-      { "number": 1, "row": 0, "col": 0 },
-      { "number": 4, "row": 3, "col": 1 }
-    ],
-    "verticalHints": [
-      { "number": 2, "row": 0, "col": 1 },
-      { "number": 3, "row": 2, "col": 3 }
-    ]
-  },
-  {
-    "quiz": 17,
-    "rows": 3,
-    "columns": 4,
-    "hintRows": 4,
-    "disabledCells": [
-      { "row": 0, "col": 1 },
-      { "row": 0, "col": 2 },
-      { "row": 0, "col": 3 },
-      { "row": 1, "col": 1 },
-      { "row": 2, "col": 3 }
-    ],
-    "horizontalHints": [
-      { "number": 2, "row": 2, "col": 0 },
-      { "number": 4, "row": 1, "col": 2 }
-    ],
-    "verticalHints": [
-      { "number": 1, "row": 0, "col": 0 },
-      { "number": 3, "row": 1, "col": 2 }
-    ]
-  },
-  {
-    "quiz": 18,
-    "rows": 4,
-    "columns": 5,
-    "hintRows": 4,
-    "disabledCells": [
-      { "row": 0, "col": 0 },
-      { "row": 0, "col": 1 },
-      { "row": 0, "col": 2 },
-      { "row": 0, "col": 3 },
-      { "row": 1, "col": 0 },
-      { "row": 1, "col": 1 },
-      { "row": 2, "col": 0 },
-      { "row": 2, "col": 1 },
-      { "row": 2, "col": 3 },
-      { "row": 3, "col": 3 },
-      { "row": 3, "col": 4 }
-    ],
-    "horizontalHints": [
-      { "number": 2, "row": 1, "col": 2 },
-      { "number": 4, "row": 3, "col": 0 }
-    ],
-    "verticalHints": [
-      { "number": 1, "row": 0, "col": 4 },
-      { "number": 3, "row": 1, "col": 2 }
-    ]
-  },
-  {
-    "quiz": 19,
-    "rows": 3,
-    "columns": 5,
-    "hintRows": 4,
-    "disabledCells": [
-      { "row": 0, "col": 3 },
-      { "row": 1, "col": 0 },
-      { "row": 1, "col": 2 },
-      { "row": 1, "col": 3 },
       { "row": 2, "col": 0 },
       { "row": 2, "col": 1 }
     ],
     "horizontalHints": [
       { "number": 1, "row": 0, "col": 0 },
-      { "number": 4, "row": 2, "col": 2 }
+      { "number": 4, "row": 3, "col": 0 }
     ],
     "verticalHints": [
       { "number": 2, "row": 0, "col": 1 },
-      { "number": 3, "row": 0, "col": 4 }
-    ]
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
   },
   {
-    "quiz": 20,
-    "rows": 3,
-    "columns": 6,
+    "quiz": 3,
+    "rows": 4,
+    "columns": 3,
     "hintRows": 4,
     "disabledCells": [
-      { "row": 0, "col": 2 },
-      { "row": 0, "col": 3 },
-      { "row": 0, "col": 5 },
       { "row": 1, "col": 0 },
       { "row": 1, "col": 2 },
       { "row": 2, "col": 0 },
-      { "row": 2, "col": 1 },
-      { "row": 2, "col": 2 },
-      { "row": 2, "col": 3 },
-      { "row": 2, "col": 5 }
+      { "row": 2, "col": 1 }
     ],
     "horizontalHints": [
       { "number": 1, "row": 0, "col": 0 },
-      { "number": 4, "row": 1, "col": 3 }
+      { "number": 4, "row": 3, "col": 0 }
     ],
     "verticalHints": [
       { "number": 2, "row": 0, "col": 1 },
-      { "number": 3, "row": 0, "col": 4 }
-    ]
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 4,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 5,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 6,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 7,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 8,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 9,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 10,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 11,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 12,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 13,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 14,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 15,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 16,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 17,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 18,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 19,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 20,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 21,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 22,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 23,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 24,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 25,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 26,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 27,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 28,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 29,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 30,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 31,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 32,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 33,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 34,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 35,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 36,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 37,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 38,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 39,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 40,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 41,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 42,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 43,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 44,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 45,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 46,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 47,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 48,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 49,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 50,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 51,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 52,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 53,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 54,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 55,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 56,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 57,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 58,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 59,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 60,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 61,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 62,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 63,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 64,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 65,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 66,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 67,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 68,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 69,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 70,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 71,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 72,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 73,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 74,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 75,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 76,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 77,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 78,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 79,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 80,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 81,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 82,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 83,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 84,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 85,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 86,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 87,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 88,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 89,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 90,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 91,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 92,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 93,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 94,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 95,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 96,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 97,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 98,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 99,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
+  },
+  {
+    "quiz": 100,
+    "rows": 4,
+    "columns": 3,
+    "hintRows": 4,
+    "disabledCells": [
+      { "row": 1, "col": 0 },
+      { "row": 1, "col": 2 },
+      { "row": 2, "col": 0 },
+      { "row": 2, "col": 1 }
+    ],
+    "horizontalHints": [
+      { "number": 1, "row": 0, "col": 0 },
+      { "number": 4, "row": 3, "col": 0 }
+    ],
+    "verticalHints": [
+      { "number": 2, "row": 0, "col": 1 },
+      { "number": 3, "row": 2, "col": 2 }
+    ],
+    "answers": {
+      "0_0": "유",
+      "0_1": "모",
+      "0_2": "차",
+      "1_1": "자",
+      "2_2": "오",
+      "3_0": "병",
+      "3_1": "아",
+      "3_2": "리"
+    }
   }
 ]

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -6,37 +6,15 @@ export default function Home() {
       <div className="contents-main">
         <div className="main-title">
           <p className="select-function">듣기연습 선택</p>
-          <p className="select-function small-text">
-            실행할 듣기 연습 종류를 선택하세요.
-          </p>
+          <p className="select-function small-text">연습할 듣기 종류를 고르세요.</p>
         </div>
         <div className="functions-wrapper">
           <ul>
-            <FunctionList
-              _to="/training/part1"
-              _num="01"
-              _title={`소음 하\n문장 듣기`}
-            />
-            <FunctionList
-              _to="/training/part2"
-              _num="02"
-              _title={`짧은 이야기\n듣기`}
-            />
-            <FunctionList
-              _to="/training/part3"
-              _num="03"
-              _title={`긴 이야기\n듣기`}
-            />
-            <FunctionList
-              _to="/training/part4"
-              _num="04"
-              _title={`문장\n순서화 하기`}
-            />
-            <FunctionList
-              _to="/training/part5"
-              _num="05"
-              _title={`가로세로\n퀴즈`}
-            />
+            <FunctionList _to="/training/part1" _num="01" _title={`소음 하\n문장 듣기`} />
+            <FunctionList _to="/training/part2" _num="02" _title={`짧은 이야기\n듣기`} />
+            <FunctionList _to="/training/part3" _num="03" _title={`긴 이야기\n듣기`} />
+            <FunctionList _to="/training/part4" _num="04" _title={`문장\n순서화 하기`} />
+            <FunctionList _to="/training/part5" _num="05" _title={`가로세로\n퀴즈`} />
           </ul>
         </div>
       </div>

--- a/src/pages/tests/test05/CrosswordQuiz.tsx
+++ b/src/pages/tests/test05/CrosswordQuiz.tsx
@@ -2,6 +2,10 @@ import { Link, useParams } from "react-router-dom";
 import CrosswordGrid from "../../../components/tests/test05/CrosswordGrid";
 import crosswordData from "../../../data/crosswordData.json";
 import { useEffect, useState } from "react";
+import CustomInputButton from "@components/tests/CustomInputButton";
+import { testModalState } from "@states/index";
+import { useRecoilState } from "recoil";
+import Modal from "@components/common/Modal";
 
 interface QuizData {
   quiz: number;
@@ -11,12 +15,15 @@ interface QuizData {
   disabledCells: Array<{ row: number; col: number }>;
   horizontalHints: Array<{ number: number; row: number; col: number }>;
   verticalHints: Array<{ number: number; row: number; col: number }>;
+  answers: { [key: string]: string };
 }
 
 export default function CrosswordQuiz() {
   const { quiz } = useParams<{ quiz?: string }>();
   const [quizData, setQuizData] = useState<QuizData | null>(null);
   const quizNum = parseInt(quiz ?? "1", 10);
+  const [testModal, setTestModal] = useRecoilState(testModalState);
+  const [showAnswers, setShowAnswers] = useState(false);
 
   useEffect(() => {
     const currentQuizData = crosswordData.find((data) => data.quiz === quizNum);
@@ -25,6 +32,7 @@ export default function CrosswordQuiz() {
 
   return (
     <div className="contents-wrapper main">
+      {testModal && <Modal setModal={setTestModal} modalText="훈련을 마쳤습니다." />}
       <div className="contents-main crossword">
         <div className="main-title menu no-margin-bottom">
           <p className="select-function menu-title menu-title-color">
@@ -34,18 +42,26 @@ export default function CrosswordQuiz() {
           <p className="quiz-rule">{`${quiz}. 파란색 번호는 가로, 녹색 번호는 세로 문제입니다.`}</p>
         </div>
         <div className="quiz-btn-wrapper">
-          <Link to="/">
-            <img
-              src={`${process.env.PUBLIC_URL}/images/test/show_answer.png`}
-              alt="Show Answer Button"
-            />
-          </Link>
-          <Link to="/">
-            <img
-              src={`${process.env.PUBLIC_URL}/images/test/next_quiz.png`}
-              alt="Next Quiz Button"
-            />
-          </Link>
+          <CustomInputButton
+            type="radio"
+            id="nextQuiz"
+            imageName="next_quiz"
+            name="nextQuiz"
+            className="answer-buttons__opacity_1"
+            onClick={() => {
+              setTestModal(true);
+            }}
+          />
+          <CustomInputButton
+            type="radio"
+            id="showAnswer"
+            imageName="show_answer"
+            name="showAnswer"
+            className="answer-buttons__opacity_1"
+            onClick={() => {
+              setShowAnswers(!showAnswers);
+            }}
+          />
         </div>
       </div>
       {quizData && (
@@ -56,6 +72,7 @@ export default function CrosswordQuiz() {
           disabledCells={quizData.disabledCells}
           horizontalHints={quizData.horizontalHints}
           verticalHints={quizData.verticalHints}
+          answers={showAnswers ? quizData.answers : {}}
         />
       )}
     </div>

--- a/src/states/index.ts
+++ b/src/states/index.ts
@@ -6,8 +6,13 @@ const { persistAtom } = recoilPersist({
   converter: JSON,
 });
 
-export const myPageModalState = atom({
-  key: "isMyPageOpen",
+export const modalState = atom({
+  key: "isModalOpen",
+  default: false,
+});
+
+export const testModalState = atom({
+  key: "isTestModalOpen",
   default: false,
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1666,6 +1666,21 @@
     schema-utils "^3.0.0"
     source-map "^0.7.3"
 
+"@react-dnd/asap@^5.0.1":
+  version "5.0.2"
+  resolved "https://registry.npmjs.org/@react-dnd/asap/-/asap-5.0.2.tgz"
+  integrity sha512-WLyfoHvxhs0V9U+GTsGilGgf2QsPl6ZZ44fnv0/b8T3nQyvzxidxsg/ZltbWssbsRDlYW8UKSQMTGotuTotZ6A==
+
+"@react-dnd/invariant@^4.0.1":
+  version "4.0.2"
+  resolved "https://registry.npmjs.org/@react-dnd/invariant/-/invariant-4.0.2.tgz"
+  integrity sha512-xKCTqAK/FFauOM9Ta2pswIyT3D8AQlfrYdOi/toTPEhqCuAs1v5tcJ3Y08Izh1cJ5Jchwy9SeAXmMg6zrKs2iw==
+
+"@react-dnd/shallowequal@^4.0.1":
+  version "4.0.2"
+  resolved "https://registry.npmjs.org/@react-dnd/shallowequal/-/shallowequal-4.0.2.tgz"
+  integrity sha512-/RVXdLvJxLg4QKvMoM5WlwNR9ViO9z8B/qPcc+C0Sa/teJY7QG7kJ441DwzOjMYEY7GmU4dj5EcGHIkKZiQZCA==
+
 "@remix-run/router@1.10.0":
   version "1.10.0"
   resolved "https://registry.npmjs.org/@remix-run/router/-/router-1.10.0.tgz"
@@ -2131,7 +2146,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*", "@types/node@^16.18.58":
+"@types/node@*", "@types/node@^16.18.58", "@types/node@>= 12":
   version "16.18.58"
   resolved "https://registry.npmjs.org/@types/node/-/node-16.18.58.tgz"
   integrity sha512-YGncyA25/MaVtQkjWW9r0EFBukZ+JulsLcVZBlGUfIb96OBMjkoRWwQo5IEWJ8Fj06Go3GHw+bjYDitv6BaGsA==
@@ -2173,7 +2188,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^18.2.28":
+"@types/react@*", "@types/react@^18.2.28", "@types/react@>= 16":
   version "18.2.28"
   resolved "https://registry.npmjs.org/@types/react/-/react-18.2.28.tgz"
   integrity sha512-ad4aa/RaaJS3hyGz0BGegdnSRXQBkd1CCYDCdNjBPg90UUpLgo+WlJqb9fMYUxtehmzF3PJaTWqRZjko6BRzBg==
@@ -4029,6 +4044,15 @@ dlv@^1.1.3:
   resolved "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz"
   integrity sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==
 
+dnd-core@^16.0.1:
+  version "16.0.1"
+  resolved "https://registry.npmjs.org/dnd-core/-/dnd-core-16.0.1.tgz"
+  integrity sha512-HK294sl7tbw6F6IeuK16YSBUoorvHpY8RHO+9yFfaJyCDVb6n7PRcezrOEOa2SBCqiYpemh5Jx20ZcjKdFAVng==
+  dependencies:
+    "@react-dnd/asap" "^5.0.1"
+    "@react-dnd/invariant" "^4.0.1"
+    redux "^4.2.0"
+
 dns-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz"
@@ -5254,6 +5278,13 @@ he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/he/-/he-1.2.0.tgz"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
+hoist-non-react-statics@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz"
+  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
+  dependencies:
+    react-is "^16.7.0"
 
 hoopy@^0.1.4:
   version "0.1.4"
@@ -7999,6 +8030,24 @@ react-dev-utils@^12.0.1:
     strip-ansi "^6.0.1"
     text-table "^0.2.0"
 
+react-dnd-html5-backend@^16.0.1:
+  version "16.0.1"
+  resolved "https://registry.npmjs.org/react-dnd-html5-backend/-/react-dnd-html5-backend-16.0.1.tgz"
+  integrity sha512-Wu3dw5aDJmOGw8WjH1I1/yTH+vlXEL4vmjk5p+MHxP8HuHJS1lAGeIdG/hze1AvNeXWo/JgULV87LyQOr+r5jw==
+  dependencies:
+    dnd-core "^16.0.1"
+
+react-dnd@^16.0.1:
+  version "16.0.1"
+  resolved "https://registry.npmjs.org/react-dnd/-/react-dnd-16.0.1.tgz"
+  integrity sha512-QeoM/i73HHu2XF9aKksIUuamHPDvRglEwdHL4jsp784BgUuWcg6mzfxT0QDdQz8Wj0qyRKx2eMg8iZtWvU4E2Q==
+  dependencies:
+    "@react-dnd/invariant" "^4.0.1"
+    "@react-dnd/shallowequal" "^4.0.1"
+    dnd-core "^16.0.1"
+    fast-deep-equal "^3.1.3"
+    hoist-non-react-statics "^3.3.2"
+
 react-dom@^18.0.0, react-dom@^18.2.0, react-dom@>=16.8:
   version "18.2.0"
   resolved "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz"
@@ -8018,6 +8067,11 @@ react-hook-form@^7.48.1:
   integrity sha512-H0T2InFQb1hX7qKtDIZmvpU1Xfn/bdahWBN1fH19gSe4bBEqTfmlr7H3XWTaVtiK4/tpPaI1F3355GPMZYge+A==
 
 react-is@^16.13.1:
+  version "16.13.1"
+  resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -8107,7 +8161,7 @@ react-scripts@^5.0.0, react-scripts@^5.0.1:
   optionalDependencies:
     fsevents "^2.3.2"
 
-"react@^16.8.0 || ^17 || ^18", react@^18.0.0, react@^18.2.0, "react@>= 16", react@>=16.13.1, react@>=16.8:
+"react@^16.8.0 || ^17 || ^18", react@^18.0.0, react@^18.2.0, "react@>= 16", "react@>= 16.14", react@>=16.13.1, react@>=16.8:
   version "18.2.0"
   resolved "https://registry.npmjs.org/react/-/react-18.2.0.tgz"
   integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
@@ -8176,6 +8230,13 @@ redent@^3.0.0:
   dependencies:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
+
+redux@^4.2.0:
+  version "4.2.1"
+  resolved "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz"
+  integrity sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
 
 reflect.getprototypeof@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
## 📃변경 사항
### 로그인 페이지
- [x] 폰트 크기를 조정했습니다.

### 메인 화면
- [x] 헤더의 문구를 수정했습니다. (말귀연습 → 말귀)
- [x] 제목 하단 설명 문구를 수정했습니다.

### 테스트 화면 공통
- [x] 학습률 디자인을 수정했습니다.
- [x] 테스트 종료 시 나오는 모달창을 디자인했습니다.
  - (Test01, Test02) 마지막 퀴즈 화면에서 렌더링 됩니다.
  - (Test03) "제출하기" 버튼을 클릭했을 때 렌더링 됩니다.
  - (Test04) "다음퀴즈보기" 버튼을 클릭했을 때 렌더링 됩니다.
  - (Test05) "다음문제풀기" 버튼을 클릭했을 때 렌더링 됩니다.
- [x] 각종 버튼을 컴포넌트화했습니다.

### 소음 하 문장듣기
- [x] 기초 난이도 이상에서 "소음없이듣기" 버튼을 추가했습니다.

### 짧은 이야기 듣기
- [x] "이야기 보기" 버튼을 클릭했을 때, 꺾임쇠가 다르게 보이도록 수정했습니다.
- [x] 이야기와 정답을 동시에 렌더링 되지 않게 수정하여 레이아웃이 무너지는 문제를 방지했습니다.

### 긴 이야기 듣기
- [x] 문제를 채점 여부에 따라 하나씩 렌더링하도록 수정했습니다.

### 문장 순서화 하기
- [x] 문장을 드래그하여 순서를 맞추는 방식으로 변경했습니다. (오류 발생 가능성 있음)
- [x] 문장을 올바른 순서로 배치했을 때, 텍스트가 녹색으로 변경되며 드래그가 불가하게 구현했습니다.
- [x] 문장을 무작위로 제시하도록 구현했습니다. (정답 순서와 일치하게 제시되지 않음)
- [x] 문장을 하나만 재생하게 수정했습니다.

### 가로세로 퀴즈
- [x] 채점 버튼이 정상적으로 동작하도록 수정했습니다.
- [x] "정답보기" 버튼을 클릭하면 정답이 나타납니다.
- [x] `readOnly` 속성을 사용하여 사용자가 `input` 태그에 직접 상호작용을 할 수 없게 수정했습니다.